### PR TITLE
Fixed Chrome Audio

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -547,6 +547,11 @@
                 triggerReady("document");
             });
             
+            document.addEventListener("mousedown", function () {
+                if(window.vbaSound.audioCtx.state === "suspended"){
+                    window.vbaSound.audioCtx.resume();
+                }
+            });
 
             onReady("document", function () {
                 if (window.init) {


### PR DESCRIPTION
Another little fix.
Chrome was requiring user input before it lets you use the audio context.

This just resumes the context after the first interaction.
Might want to handle this in a better manner but for now it seems to work.

https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio

Fixes: #10 